### PR TITLE
feat: added location-wise appointments endpoint with OpenMRS enrichment and pagination

### DIFF
--- a/portal/controllers/appointment.controller.js
+++ b/portal/controllers/appointment.controller.js
@@ -24,7 +24,8 @@ const {
   _completeAppointment,
   checkAppointment,
   updateSlotSpeciality,
-  validateDayOff
+  validateDayOff,
+  getAllAppointmentsByLocation
 } = require("../services/appointment.service");
 
 module.exports = (function () {
@@ -566,6 +567,31 @@ module.exports = (function () {
         data,
       });
     } catch (error) {
+      next(error);
+    }
+  };
+
+  /**
+   * Get all appointments by location UUID
+   * @param {*} req
+   * @param {*} res
+   */
+  this.getAllAppointmentsByLocation = async (req, res, next) => {
+    try {
+      logStream('debug', 'API calling', 'Get All Appointments By Location');
+      const keysAndTypeToCheck = [
+        { key: Constant.LOCATION_UUID, type: 'string' },
+      ];
+      if (validateParams(req.params, keysAndTypeToCheck)) {
+        const { locationUuid } = req.params;
+        const page = Math.max(parseInt(req.query.page, 10) || 1, 1);
+        const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 20, 1), 100);
+        const data = await getAllAppointmentsByLocation(locationUuid, { page, limit });
+        logStream('debug', 'Got All Appointments By Location', 'Get All Appointments By Location');
+        res.json(data);
+      }
+    } catch (error) {
+      logStream('error', error.message);
       next(error);
     }
   };

--- a/portal/routes/appointment.route.js
+++ b/portal/routes/appointment.route.js
@@ -18,7 +18,8 @@ const {
   appointmentPush,
   checkAppointment,
   updateSlotSpeciality,
-  validateDayOff
+  validateDayOff,
+  getAllAppointmentsByLocation
 } = require("../controllers/appointment.controller");
 const authMiddleware = require("../middleware/auth");
 const router = express.Router();
@@ -33,6 +34,7 @@ router.get('/validateDayOff/:userUuid', [authMiddleware, validateDayOff]);
 router.get("/getSlots", [authMiddleware, getSlots]);
 router.get("/getAppointmentSlots", [authMiddleware, getAppointmentSlots]);
 router.get("/getScheduledMonths/:userUuid", [authMiddleware, getScheduledMonths]);
+router.get("/getAllAppointmentsByLocation/:locationUuid", [authMiddleware, getAllAppointmentsByLocation]);
 router.post("/createOrUpdateSchedule", [authMiddleware, upsertSchedule]);
 router.post("/bookAppointment", bookAppointment); // TODO: removed the authMiddleware it's calling from MRS middleware pull/push
 router.post("/rescheduleAppointment", rescheduleAppointment); // TODO: removed the authMiddleware it's calling from MRS middleware pull/push

--- a/portal/services/appointment.service.js
+++ b/portal/services/appointment.service.js
@@ -3,6 +3,7 @@ const {
   appointments: Appointment,
   appointment_settings: Setting,
   Sequelize,
+  sequelize: mainSequelize,
 } = require("../models");
 const Op = Sequelize.Op;
 
@@ -1469,6 +1470,131 @@ WHERE
       }
     }
   }
+
+  /**
+   * Get all appointments by location UUID
+   * @param { string } locationUuid - Location UUID
+   */
+  this.getAllAppointmentsByLocation = async (locationUuid, { page = 1, limit = 20 } = {}) => {
+    try {
+      logStream('debug', 'Appointment Service', 'Get All Appointments By Location');
+      const offset = (page - 1) * limit;
+      const countQuery = `SELECT COUNT(*) AS total FROM appointments WHERE locationUuid = ?`;
+      const totalResult = await mainSequelize.query(countQuery, {
+        replacements: [locationUuid],
+        type: QueryTypes.SELECT,
+      });
+      const total = Number(totalResult?.[0]?.total || 0);
+
+      const query = `SELECT * FROM appointments WHERE locationUuid = ? ORDER BY slotJsDate DESC LIMIT ? OFFSET ?`;
+      const rows = await mainSequelize.query(query, {
+        replacements: [locationUuid, limit, offset],
+        type: QueryTypes.SELECT,
+      });
+
+      const visitUuids = [...new Set(rows.map((row) => row.visitUuid).filter(Boolean))];
+      const visitRecords = visitUuids.length
+        ? await visit.findAll({
+            where: { uuid: { [Op.in]: visitUuids } },
+            attributes: ["uuid"],
+            include: [
+              {
+                model: person_name,
+                as: "patient_name",
+                attributes: ["given_name", "family_name"],
+                required: false,
+              },
+              {
+                model: person,
+                as: "person",
+                attributes: ["gender", "birthdate", "uuid"],
+                required: false,
+              },
+              {
+                model: visit_attribute,
+                as: "attributes",
+                attributes: [["value_reference", "value"]],
+                required: false,
+                include: [
+                  {
+                    model: visit_attribute_type,
+                    as: "attribute_type",
+                    attributes: ["name", "uuid"],
+                  },
+                ],
+              },
+            ],
+          })
+        : [];
+
+      const visitMap = new Map(visitRecords.map((visitItem) => [visitItem.uuid, visitItem]));
+
+      const getPatientName = (visitItem) => {
+        const givenName = visitItem?.patient_name?.given_name || "";
+        const familyName = visitItem?.patient_name?.family_name || "";
+        const fullName = `${givenName} ${familyName}`.trim();
+        return fullName || null;
+      };
+
+      const getPatientAge = (visitItem) => {
+        const birthDate = visitItem?.person?.birthdate;
+        if (!birthDate) return null;
+        return String(moment().diff(moment(birthDate), "years"));
+      };
+
+      const getVisitSpeciality = (visitItem) => {
+        const specialityAttribute = (visitItem?.attributes || []).find((attributeItem) => {
+          return attributeItem?.attribute_type?.name === "Visit Speciality";
+        });
+
+        const specialityValue = specialityAttribute?.dataValues?.value || specialityAttribute?.value;
+        if (typeof specialityValue === "string" && specialityValue.trim()) {
+          return specialityValue.trim();
+        }
+
+        return null;
+      };
+
+      const locationRecord = await location.findOne({
+        where: { uuid: locationUuid },
+        attributes: ['uuid', 'name'],
+      });
+      const clinicName = locationRecord?.name || locationUuid;
+
+      const appointments = rows.map((item) => {
+        const visitItem = visitMap.get(item.visitUuid);
+        return {
+          patientName: getPatientName(visitItem) || item.patientName || null,
+          patientAge: getPatientAge(visitItem) || item.patientAge || null,
+          patientGender: visitItem?.person?.gender || item.patientGender || null,
+          complaint: getVisitSpeciality(visitItem) || item.reason || item.speciality || null,
+          appointmentDate: item.slotDate || null,
+          appointmentTime: item.slotTime || null,
+          locationName: clinicName,
+        };
+      });
+      logStream('debug', 'Got All Appointments By Location', 'Get All Appointments By Location');
+      return {
+        code: 200,
+        success: true,
+        data: appointments,
+        pagination: {
+          page,
+          limit,
+          total,
+          totalPages: Math.ceil(total / limit),
+          hasNextPage: page * limit < total,
+          hasPreviousPage: page > 1,
+        },
+      };
+    } catch (error) {
+      logStream('error', error.message);
+      if (error.code === null || error.code === undefined) {
+        error.code = 500;
+      }
+      return { code: error.code, success: false, data: error.data, message: error.message };
+    }
+  };
 
   return this;
 })();


### PR DESCRIPTION
Added GET endpoint to fetch appointments by selected location UUID.
Protected endpoint with auth middleware (Bearer token required).
Implemented location filter on portal appointments and mapped response to:
patientName
patientAge
patientGender
complaint
appointmentDate
appointmentTime
locationName
Enriched patient details from OpenMRS using visitUuid:
Name from person_name
Gender and birthdate from person (age derived from birthdate)
Updated complaint source to OpenMRS Visit Speciality (visit_attribute + visit_attribute_type) with fallback values.
Added pagination support using query params page and limit.
Added pagination metadata in response:
page, limit, total, totalPages, hasNextPage, hasPreviousPage
Updated Swagger docs for the endpoint, including pagination params and updated response schema.
Validated endpoint against latest DB dump and confirmed populated real data is returned.