### PR TITLE
Pin uuid override to ^9.0.1 across all backend services

### DIFF
--- a/auth-gateway/package.json
+++ b/auth-gateway/package.json
@@ -7,7 +7,7 @@
     "npm": ">=9.0.0"
   },
   "overrides": {
-    "uuid": "^14.0.0"
+    "uuid": "^9.0.1"
   },
   "scripts": {
     "start": "node ./bin/www",

--- a/configuration-microservice/package.json
+++ b/configuration-microservice/package.json
@@ -33,7 +33,7 @@
     "npm": ">=9.0.0"
   },
   "overrides": {
-    "uuid": "^14.0.0",
+    "uuid": "^9.0.1",
     "tar": "^7.5.11"
   },
   "dependencies": {

--- a/pagerduty-microservice/package.json
+++ b/pagerduty-microservice/package.json
@@ -7,7 +7,7 @@
     "npm": ">=9.0.0"
   },
   "overrides": {
-    "uuid": "^14.0.0"
+    "uuid": "^9.0.1"
   },
   "scripts": {
     "start": "node ./bin/www",

--- a/portal/package.json
+++ b/portal/package.json
@@ -7,7 +7,7 @@
     "npm": ">=9.0.0"
   },
   "overrides": {
-    "uuid": "^14.0.0",
+    "uuid": "^9.0.1",
     "cookie": "^0.7.0",
     "@tootallnate/once": "^3.0.1",
     "tar": "^7.5.11",

--- a/web-rtc/package.json
+++ b/web-rtc/package.json
@@ -8,7 +8,7 @@
     "npm": ">=9.0.0"
   },
   "overrides": {
-    "uuid": "^14.0.0"
+    "uuid": "^9.0.1"
   },
   "scripts": {
     "start": "ts-node src/index.ts",


### PR DESCRIPTION
Sequelize 6 uses require("uuid").v1, which is CommonJS. The previous override pinned uuid to ^14.0.0 (ESM-only), causing ERR_REQUIRE_ESM crashes on startup in portal, auth-gateway, web-rtc, pagerduty-microservice and configuration-microservice. uuid ^9.0.1 is the last CommonJS-compatible release and works with Sequelize 6 and firebase-admin 13.